### PR TITLE
add support for newer velero versions

### DIFF
--- a/content/en/docs/01/resources/velero/values.yaml
+++ b/content/en/docs/01/resources/velero/values.yaml
@@ -1,12 +1,13 @@
 configuration:
-  provider: aws
   backupStorageLocation:
-    bucket: <username>-ops-training-backup-velero
-    config:
-      region: us-east-1
+    - provider: aws
+      bucket: <username>-ops-training-backup-velero
+      config:
+        region: us-east-1
   volumeSnapshotLocation:
-    config:
-      region: us-east-1
+    - provider: aws
+      config:
+        region: us-east-1
 initContainers:
   - name: velero-plugin-for-aws
     image: velero/velero-plugin-for-aws


### PR DESCRIPTION
.configuration.provider has been removed, instead each backupStorageLocation and volumeSnapshotLocation has a provider configured