### PR TITLE
Update deprecated ArgoCD API version

### DIFF
--- a/content/en/docs/05/resources/argocd_openshift-gitops.yaml
+++ b/content/en/docs/05/resources/argocd_openshift-gitops.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: openshift-gitops


### PR DESCRIPTION
Warning: ArgoCD v1alpha1 version is deprecated and will be converted to v1beta1 automatically. Moving forward, please use v1beta1 as the ArgoCD API version.